### PR TITLE
Emergency downgrade to 0.6.9

### DIFF
--- a/re.fossplant.songrec.json
+++ b/re.fossplant.songrec.json
@@ -39,8 +39,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://github.com/marin-m/SongRec/releases/download/0.7.0/songrec_tarball_0.7.0_for_flathub_build.tar.gz",
-                    "sha256": "16a5697afc51aa68b075242bbfd300ed94dd7f0e154294a1d57d5027bfd32184"
+                    "url": "https://github.com/marin-m/SongRec/releases/download/0.6.9/songrec_tarball_0.6.9_for_flathub_build.tar.gz",
+                    "sha256": "4e06369225fc7f0473fa1e361d966bee26edef987ac0dedc3e270b42b033242e"
                 }
             ]
         }


### PR DESCRIPTION
Emergency downgrade because of:

```
[2026-05-09T11:28:19Z DEBUG songrec::gui::main_window src/gui/main_window.rs:856] Received GUI message: ErrorMessage("Erreur audio\u{a0}: stream error: RealtimeDenied - Failed to promote audio thread to real-time priority: AudioThreadPriorityError: org.freedesktop.DBus.Error.FileNotFound:Failed to connect to socket /run/dbus/system_bus_socket: Aucun fichier ou dossier de ce nom - Real-time scheduling was requested but not granted for the audio thread. Audio may be subject to increased latency or glitches under load.")
[2026-05-09T11:28:19Z ERROR songrec::gui::main_window src/gui/main_window.rs:913] Displaying error: Erreur audio : stream error: RealtimeDenied - Failed to promote audio thread to real-time priority: AudioThreadPriorityError: org.freedesktop.DBus.Error.FileNotFound:Failed to connect to socket /run/dbus/system_bus_socket: Aucun fichier ou dossier de ce nom - Real-time scheduling was requested but not granted for the audio thread. Audio may be subject to increased latency or glitches under load.
```